### PR TITLE
読み中の記号での失敗と、未収録モーラの同音フォールバック

### DIFF
--- a/internal/frontend/kana.go
+++ b/internal/frontend/kana.go
@@ -19,7 +19,7 @@ func ParseKana(reading string) ([]Mora, error) {
 	reading = norm.NFC.String(reading)
 	var result []Mora
 	for _, r := range reading {
-		if unicode.IsSpace(r) || strings.ContainsRune("、。，．,.!?！？・", r) {
+		if unicode.IsSpace(r) || strings.ContainsRune("、。，．,.!?！？・…‥〜～（）「」『』", r) {
 			if len(result) > 0 && !result[len(result)-1].Pause {
 				result = append(result, Mora{Pause: true})
 			}

--- a/internal/frontend/kana_test.go
+++ b/internal/frontend/kana_test.go
@@ -36,6 +36,32 @@ func TestParseKanaLongVowel(t *testing.T) {
 	}
 }
 
+func TestParseKanaEllipsisAndBrackets(t *testing.T) {
+	got, err := ParseKana("ミナサン……（テスト）〜オハヨー〜")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []Mora{
+		{Text: "み", Consonant: "m", Vowel: "i"},
+		{Text: "な", Consonant: "n", Vowel: "a"},
+		{Text: "さ", Consonant: "s", Vowel: "a"},
+		{Text: "ん", Consonant: "n", Vowel: "n"},
+		{Pause: true},
+		{Text: "て", Consonant: "t", Vowel: "e"},
+		{Text: "す", Consonant: "s", Vowel: "u"},
+		{Text: "と", Consonant: "t", Vowel: "o"},
+		{Pause: true},
+		{Text: "お", Vowel: "o"},
+		{Text: "は", Consonant: "h", Vowel: "a"},
+		{Text: "よ", Consonant: "y", Vowel: "o"},
+		{Text: "ー", Vowel: "o"},
+		{Pause: true},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("morae = %#v, want %#v", got, want)
+	}
+}
+
 func TestParseKanaConsonants(t *testing.T) {
 	got, err := ParseKana("かしゃつきょんっ")
 	if err != nil {

--- a/internal/voicebank/resolver.go
+++ b/internal/voicebank/resolver.go
@@ -353,6 +353,34 @@ func aliasCandidates(mora, previousVowel string, phraseStart bool) []aliasCandid
 	return aliasCandidatesWithPolicy(mora, previousVowel, phraseStart, AliasPolicyAuto)
 }
 
+// equivalentKanaForms returns kana that are pronounced identically to the
+// given mora in modern standard Japanese. These are safe fallbacks for
+// voicebanks that lack a dedicated recording:
+//
+//	を = お   (the particle を is pronounced "o")
+//	ぢ = じ   (di and ji merged)
+//	づ = ず   (du and zu merged)
+//	ゐ = い   (archaic wi = i)
+//	ゑ = え   (archaic we = e)
+//
+// Small-kana combinations (てぃ, とぅ, ふぁ, ...) are NOT included because
+// they are genuinely different sounds.
+func equivalentKanaForms(mora string) []string {
+	switch mora {
+	case "を":
+		return []string{"お"}
+	case "ぢ":
+		return []string{"じ"}
+	case "づ":
+		return []string{"ず"}
+	case "ゐ":
+		return []string{"い"}
+	case "ゑ":
+		return []string{"え"}
+	}
+	return nil
+}
+
 func aliasCandidatesWithPolicy(mora, previousVowel string, phraseStart bool, policy AliasPolicy) []aliasCandidate {
 	forms := make([]string, 0, 4)
 	if mora == "ー" {
@@ -360,10 +388,17 @@ func aliasCandidatesWithPolicy(mora, previousVowel string, phraseStart bool, pol
 			forms = append(forms, vowelKana, toKatakana(vowelKana))
 		}
 	}
-	forms = append(forms, mora)
-	katakana := toKatakana(mora)
-	if katakana != mora {
-		forms = append(forms, katakana)
+	// The mora itself plus phonetically identical alternates (modern
+	// standard Japanese), so voicebanks that lack a dedicated recording
+	// still synthesize the mora: を=お, ぢ=じ, づ=ず, ゐ=い, ゑ=え.
+	// The original forms come first so banks with a dedicated entry use it.
+	base := []string{mora}
+	base = append(base, equivalentKanaForms(mora)...)
+	for _, form := range base {
+		forms = append(forms, form)
+		if katakana := toKatakana(form); katakana != form {
+			forms = append(forms, katakana)
+		}
 	}
 
 	var candidates []aliasCandidate

--- a/internal/voicebank/resolver.go
+++ b/internal/voicebank/resolver.go
@@ -381,23 +381,34 @@ func equivalentKanaForms(mora string) []string {
 	return nil
 }
 
+// aliasForm is one surface form offered for a mora. fallback is an extra tier
+// penalty applied to phonetically-equivalent alternates (を→お etc.) so a
+// bank that owns both recordings always prefers the original kana.
+type aliasForm struct {
+	text     string
+	fallback int
+}
+
 func aliasCandidatesWithPolicy(mora, previousVowel string, phraseStart bool, policy AliasPolicy) []aliasCandidate {
-	forms := make([]string, 0, 4)
+	forms := make([]aliasForm, 0, 4)
 	if mora == "ー" {
 		if vowelKana := map[string]string{"a": "あ", "i": "い", "u": "う", "e": "え", "o": "お"}[previousVowel]; vowelKana != "" {
-			forms = append(forms, vowelKana, toKatakana(vowelKana))
+			forms = append(forms, aliasForm{text: vowelKana}, aliasForm{text: toKatakana(vowelKana)})
 		}
 	}
 	// The mora itself plus phonetically identical alternates (modern
 	// standard Japanese), so voicebanks that lack a dedicated recording
 	// still synthesize the mora: を=お, ぢ=じ, づ=ず, ゐ=い, ゑ=え.
-	// The original forms come first so banks with a dedicated entry use it.
-	base := []string{mora}
-	base = append(base, equivalentKanaForms(mora)...)
+	// Alternates carry a +1 tier penalty: the original kana must win even
+	// when both recordings exist, independent of oto.ini entry quality.
+	base := []aliasForm{{text: mora}}
+	for _, equivalent := range equivalentKanaForms(mora) {
+		base = append(base, aliasForm{text: equivalent, fallback: 1})
+	}
 	for _, form := range base {
 		forms = append(forms, form)
-		if katakana := toKatakana(form); katakana != form {
-			forms = append(forms, katakana)
+		if katakana := toKatakana(form.text); katakana != form.text {
+			forms = append(forms, aliasForm{text: katakana, fallback: form.fallback})
 		}
 	}
 
@@ -405,19 +416,19 @@ func aliasCandidatesWithPolicy(mora, previousVowel string, phraseStart bool, pol
 	allowVCVTarget := mora != "っ"
 	if policy != AliasPolicyCVOnly && allowVCVTarget && phraseStart {
 		for _, form := range forms {
-			candidates = append(candidates, aliasCandidate{name: "- " + form, tier: 0, kind: AliasVCV})
+			candidates = append(candidates, aliasCandidate{name: "- " + form.text, tier: form.fallback, kind: AliasVCV})
 		}
 	} else if policy != AliasPolicyCVOnly && allowVCVTarget && previousVowel != "" && previousVowel != "cl" {
 		for _, form := range forms {
-			candidates = append(candidates, aliasCandidate{name: previousVowel + " " + form, tier: 0, kind: AliasVCV})
+			candidates = append(candidates, aliasCandidate{name: previousVowel + " " + form.text, tier: form.fallback, kind: AliasVCV})
 		}
 	}
 	for _, form := range forms {
-		candidates = append(candidates, aliasCandidate{name: form, tier: policyTier(policy, 1, AliasCV), kind: AliasCV})
+		candidates = append(candidates, aliasCandidate{name: form.text, tier: policyTier(policy, 1, AliasCV) + form.fallback, kind: AliasCV})
 	}
 	if policy != AliasPolicyCVOnly && !phraseStart {
 		for _, form := range forms {
-			candidates = append(candidates, aliasCandidate{name: "* " + form, tier: policyTier(policy, 2, AliasCV), kind: AliasCV})
+			candidates = append(candidates, aliasCandidate{name: "* " + form.text, tier: policyTier(policy, 2, AliasCV) + form.fallback, kind: AliasCV})
 		}
 	}
 	return uniqueCandidates(candidates)

--- a/internal/voicebank/resolver_test.go
+++ b/internal/voicebank/resolver_test.go
@@ -224,6 +224,37 @@ func TestAliasCandidatesHandleSpecialMoraContexts(t *testing.T) {
 	if !contains(aliasCandidatesWithPolicy("ー", "u", false, AliasPolicyAuto), "u う") {
 		t.Fatal("long-vowel candidate did not use the preceding vowel")
 	}
+	// Phonetically identical fallbacks: を falls back to お, ぢ to じ, etc.
+	for mora, equivalent := range map[string]string{"を": "お", "ぢ": "じ", "づ": "ず", "ゐ": "い", "ゑ": "え"} {
+		candidates := aliasCandidatesWithPolicy(mora, "", true, AliasPolicyAuto)
+		if !contains(candidates, mora) {
+			t.Fatalf("mora %q candidate was not generated", mora)
+		}
+		if !contains(candidates, equivalent) {
+			t.Fatalf("mora %q did not fall back to equivalent %q", mora, equivalent)
+		}
+		if !contains(candidates, toKatakana(equivalent)) {
+			t.Fatalf("mora %q did not fall back to katakana %q", mora, toKatakana(equivalent))
+		}
+	}
+	// The original form must come before the equivalent fallback.
+	wo := aliasCandidatesWithPolicy("を", "", true, AliasPolicyAuto)
+	originalIndex, fallbackIndex := -1, -1
+	for index, candidate := range wo {
+		if candidate.name == "を" {
+			originalIndex = index
+		}
+		if candidate.name == "お" {
+			fallbackIndex = index
+		}
+	}
+	if originalIndex < 0 || fallbackIndex < 0 || originalIndex > fallbackIndex {
+		t.Fatalf("を must precede お in candidates: %v", wo)
+	}
+	// Small-kana combinations must NOT fall back (different sounds).
+	if contains(aliasCandidatesWithPolicy("てぃ", "", true, AliasPolicyAuto), "ち") {
+		t.Fatal("てぃ must not fall back to ち")
+	}
 }
 
 func TestAuditLatticeReportsAliasKindsAndSelection(t *testing.T) {

--- a/internal/voicebank/resolver_test.go
+++ b/internal/voicebank/resolver_test.go
@@ -251,9 +251,77 @@ func TestAliasCandidatesHandleSpecialMoraContexts(t *testing.T) {
 	if originalIndex < 0 || fallbackIndex < 0 || originalIndex > fallbackIndex {
 		t.Fatalf("を must precede お in candidates: %v", wo)
 	}
+	// The equivalent fallback must also carry a worse tier so the original
+	// kana keeps winning once both recordings exist.
+	originalTier, fallbackTier := -1, -1
+	for _, candidate := range wo {
+		if candidate.name == "を" {
+			originalTier = candidate.tier
+		}
+		if candidate.name == "お" {
+			fallbackTier = candidate.tier
+		}
+	}
+	if originalTier < 0 || fallbackTier <= originalTier {
+		t.Fatalf("equivalent fallback must have a worse tier than the original: %v", wo)
+	}
 	// Small-kana combinations must NOT fall back (different sounds).
 	if contains(aliasCandidatesWithPolicy("てぃ", "", true, AliasPolicyAuto), "ち") {
 		t.Fatal("てぃ must not fall back to ち")
+	}
+}
+
+// TestResolvePrefersOriginalKanaWhenBothRecordingsExist covers a bank that
+// owns dedicated recordings for both the original kana and its phonetically
+// equivalent fallback: the original must always win, and the fallback must
+// still synthesize when the dedicated recording is absent.
+func TestResolvePrefersOriginalKanaWhenBothRecordingsExist(t *testing.T) {
+	morae, err := frontend.ParseKana("あを")
+	if err != nil {
+		t.Fatal(err)
+	}
+	both := &Bank{Entries: map[string][]oto.Entry{
+		"あ":   {{Alias: "あ", Filename: "a.wav"}},
+		"- あ": {{Alias: "- あ", Filename: "a-start.wav"}},
+		"a あ": {{Alias: "a あ", Filename: "a-a.wav"}},
+		"を":   {{Alias: "を", Filename: "wo.wav", Preutterance: 30, Overlap: 20, Fixed: 40}},
+		"- を": {{Alias: "- を", Filename: "wo-start.wav", Preutterance: 30, Overlap: 20, Fixed: 40}},
+		"a を": {{Alias: "a を", Filename: "a-wo.wav", Preutterance: 30, Overlap: 20, Fixed: 40}},
+		"お":   {{Alias: "お", Filename: "o.wav", Preutterance: 30, Overlap: 20, Fixed: 40}},
+		"- お": {{Alias: "- お", Filename: "o-start.wav", Preutterance: 30, Overlap: 20, Fixed: 40}},
+		"a お": {{Alias: "a お", Filename: "a-o.wav", Preutterance: 30, Overlap: 20, Fixed: 40}},
+	}}
+	got, err := both.Resolve(morae)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("selections = %d, want 2", len(got))
+	}
+	if got[1].Alias != "a を" {
+		t.Fatalf("alias = %q, want the dedicated を recording: %#v", got[1].Alias, got[1])
+	}
+	if got[1].FallbackTier != 0 {
+		t.Fatalf("fallback tier = %d, want the original kana to keep the better tier: %#v", got[1].FallbackTier, got[1])
+	}
+
+	onlyO := &Bank{Entries: map[string][]oto.Entry{
+		"あ":   {{Alias: "あ", Filename: "a.wav"}},
+		"- あ": {{Alias: "- あ", Filename: "a-start.wav"}},
+		"a あ": {{Alias: "a あ", Filename: "a-a.wav"}},
+		"お":   {{Alias: "お", Filename: "o.wav", Preutterance: 30, Overlap: 20, Fixed: 40}},
+		"- お": {{Alias: "- お", Filename: "o-start.wav", Preutterance: 30, Overlap: 20, Fixed: 40}},
+		"a お": {{Alias: "a お", Filename: "a-o.wav", Preutterance: 30, Overlap: 20, Fixed: 40}},
+	}}
+	fallback, err := onlyO.Resolve(morae)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fallback[1].Alias != "a お" {
+		t.Fatalf("alias = %q, want the equivalent お fallback when を is absent: %#v", fallback[1].Alias, fallback[1])
+	}
+	if fallback[1].FallbackTier != 1 {
+		t.Fatalf("fallback tier = %d, want 1 for the equivalent alias: %#v", fallback[1].FallbackTier, fallback[1])
 	}
 }
 


### PR DESCRIPTION
読み中の記号での失敗と、未収録モーラの同音フォールバック

実音源での利用中に見つけた2つの問題を修正します。

1つ目は、読みに含まれる記号で合成が失敗する問題です。Open JTalkは `……` や `〜` 、括弧類を読みにそのまま透過してくるのですが、ParseKanaの停止文字集合に入っていないため "unsupported character '…' in kana reading" となっていました。既存の句読点（、。！？など）と同じ扱いで停止に変換する対象へ、`…‥〜～（）「」『』` を追加しています。

もう1つは、声庫によって未収録のモーラがある問題です。例えば `を` は現代標準語では「お」と同音なので、専用録音がなくても `お` のサンプルで代替できます。そこで別名候補へ次の同音かなフォールバックを追加しました。

| 対象 | フォールバック先 | 備考 |
|---|---|---|
| を | お | 助詞は「o」と発音される |
| ぢ / づ | じ / ず | 歴史的仮名遣いの合流 |
| ゐ / ゑ | い / え | 同上 |

元のかなを常に優先するので、専用録音を持つ音源の挙動は一切変わりません。一方でてぃ・とぅ・ふぁのような小書き組み合わせは発音自体が異なるため、意図的にフォールバック対象から外しています（てぃ→ちは誤発音になります）。

両方ともユニットテストを追加済みです。動作確認としては、記号入りの長文や「を」を含む文が、専用録音の無い音源でも正常に合成できるようになりました。

---

※ #1 のUSTX出力に依存する変更は含まれていませんが、動作確認は #1 ブランチとの組合せでも行っています。